### PR TITLE
Filter out oscillating data in passwords and certificates.

### DIFF
--- a/fnrancid-scp
+++ b/fnrancid-scp
@@ -45,3 +45,11 @@ expect -c "
    expect password: { send \"$PASSWORD\n\" }
    expect eof
 "
+
+if [ -r "${ARG_FILE}" ]; then
+    sed -E -i \
+        -e 's/^(.*) ENC .*$/\1 ENC <removed>/g' \
+        -e '/^.*set private-key.*$/,/^-----END ENCRYPTED PRIVATE KEY-----".*$/{/set private-key/ s/^(.*set private-key).*/\1 "<removed>"/; t; d}' \
+        -e '/^.*set certificate.*$/,/^-----END CERTIFICATE-----".*$/{/set certificate/ s/^(.*set certificate).*/\1 "<removed>"/; t; d}' \
+        "${ARG_FILE}"
+fi


### PR DESCRIPTION
I added some sed expression to replicate the FILTER_PWDS and FILTER_OSC configuration of RANCID, to filter out the ENCoded passwords and certificates from the forigate configuration file.